### PR TITLE
Ads sql statements

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -1,9 +1,9 @@
 USE adlister_db;
 
+DROP TABLE IF EXISTS ad_cat;
 DROP TABLE IF EXISTS ads;
 DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS categories;
-DROP TABLE IF EXISTS ad_cat;
 
 CREATE TABLE IF NOT EXISTS users (
     id INT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS ads (
      title  VARCHAR(250) NOT NULL,
      description TEXT NOT NULL,
      PRIMARY KEY (id),
-     FOREIGN KEY (user_id) REFERENCES users (id)
+     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS categories (
@@ -29,11 +29,11 @@ CREATE TABLE IF NOT EXISTS categories (
     PRIMARY KEY (id)
 );
 
-
 CREATE TABLE IF NOT EXISTS ad_cat (
     category_id INT UNSIGNED NOT NULL,
     ad_id INT UNSIGNED NOT NULL,
-    FOREIGN KEY (category_id) REFERENCES categories (id),
-    FOREIGN KEY (ad_id) REFERENCES ads (id)
+    PRIMARY KEY (category_id, ad_id),
+    FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE,
+    FOREIGN KEY (ad_id) REFERENCES ads (id) ON DELETE CASCADE
 );
 

--- a/src/main/java/com/codeup/adlister/controllers/AdPageServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/AdPageServlet.java
@@ -2,6 +2,8 @@ package com.codeup.adlister.controllers;
 
 import com.codeup.adlister.dao.DaoFactory;
 import com.codeup.adlister.models.Ad;
+import com.codeup.adlister.models.Category;
+import com.codeup.adlister.models.User;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -19,7 +21,11 @@ public class AdPageServlet extends HttpServlet {
         try {
             long id = Long.parseLong(pathString);
             Ad ad = DaoFactory.getAdsDao().getAd(id);
+            List<Category> categories = DaoFactory.getCategoriesDao().getCatsForAdId(ad.getId());
+            User user = DaoFactory.getUsersDao().findById(ad.getUserId());
             request.setAttribute("ad", ad);
+            request.setAttribute("user", user);
+            request.setAttribute("categories", categories);
             request.getRequestDispatcher("/WEB-INF/ads/ad.jsp").forward(request, response);
         } catch (NumberFormatException | NullPointerException e) {
             // if no matches are found, redirect to the ads index

--- a/src/main/java/com/codeup/adlister/controllers/AdPageServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/AdPageServlet.java
@@ -16,16 +16,14 @@ public class AdPageServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String pathString = request.getPathInfo().substring(1);
-        // bad quick solution needs to be replaced with a dao method and real SQL query
-        List<Ad> ads = DaoFactory.getAdsDao().all();
-        for (Ad ad : ads) {
-            // if any ads' ids match the path string, we send the ad info to a template page and forward user
-            if (String.valueOf(ad.getId()).equals(pathString)) {
-                request.setAttribute("ad", ad);
-                request.getRequestDispatcher("/WEB-INF/ads/ad.jsp").forward(request, response);
-            }
+        try {
+            long id = Long.parseLong(pathString);
+            Ad ad = DaoFactory.getAdsDao().getAd(id);
+            request.setAttribute("ad", ad);
+            request.getRequestDispatcher("/WEB-INF/ads/ad.jsp").forward(request, response);
+        } catch (NumberFormatException | NullPointerException e) {
+            // if no matches are found, redirect to the ads index
+            response.sendRedirect("/ads");
         }
-        // if no matches are found, redirect to the ads index
-        response.sendRedirect("/ads");
     }
 }

--- a/src/main/java/com/codeup/adlister/controllers/CreateAdServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/CreateAdServlet.java
@@ -2,6 +2,7 @@ package com.codeup.adlister.controllers;
 
 import com.codeup.adlister.dao.DaoFactory;
 import com.codeup.adlister.models.Ad;
+import com.codeup.adlister.models.Category;
 import com.codeup.adlister.models.User;
 
 import javax.servlet.ServletException;
@@ -29,6 +30,8 @@ public class CreateAdServlet extends HttpServlet {
             request.getParameter("title"),
             request.getParameter("description")
         );
+        Category cat = new Category(request.getParameter("category"));
+        DaoFactory.getCategoryDao();
         DaoFactory.getAdsDao().insert(ad);
         response.sendRedirect("/ads");
     }

--- a/src/main/java/com/codeup/adlister/controllers/CreateAdServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/CreateAdServlet.java
@@ -33,15 +33,21 @@ public class CreateAdServlet extends HttpServlet {
             request.getParameter("title"),
             request.getParameter("description")
         );
-        List<String> catStrings = Arrays.asList(request.getParameter("category").split(","));
-        List<Category> categories = new ArrayList<>();
-        for (String str : catStrings) {
-            categories.add(new Category(request.getParameter("category")));
-        }
-        Category cat = new Category(request.getParameter("category"));
-        long catId = DaoFactory.getCategoriesDao().insert(cat);
+
         long adId = DaoFactory.getAdsDao().insert(ad);
-        DaoFactory.getAdCatDao().insert(catId, adId);
+
+        // process new categories
+        List<String> catStrings = Arrays.asList(request.getParameter("category").split("\\s*,\\s*"));
+        System.out.println("all strings: " + catStrings);
+        for (String str : catStrings) {
+            System.out.println("string: " + str);
+            Category cat = new Category(str);
+            long catId = DaoFactory.getCategoriesDao().insert(cat);
+            DaoFactory.getAdCatDao().insert(catId, adId);
+        }
+        //Category cat = new Category(request.getParameter("category"));
+//        long catId = DaoFactory.getCategoriesDao().insert(cat);
+//        DaoFactory.getAdCatDao().insert(catId, adId);
         response.sendRedirect("/ads");
     }
 }

--- a/src/main/java/com/codeup/adlister/controllers/CreateAdServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/CreateAdServlet.java
@@ -11,6 +11,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @WebServlet(name = "controllers.CreateAdServlet", urlPatterns = "/ads/create")
 public class CreateAdServlet extends HttpServlet {
@@ -30,9 +33,15 @@ public class CreateAdServlet extends HttpServlet {
             request.getParameter("title"),
             request.getParameter("description")
         );
+        List<String> catStrings = Arrays.asList(request.getParameter("category").split(","));
+        List<Category> categories = new ArrayList<>();
+        for (String str : catStrings) {
+            categories.add(new Category(request.getParameter("category")));
+        }
         Category cat = new Category(request.getParameter("category"));
-        DaoFactory.getCategoryDao();
-        DaoFactory.getAdsDao().insert(ad);
+        long catId = DaoFactory.getCategoriesDao().insert(cat);
+        long adId = DaoFactory.getAdsDao().insert(ad);
+        DaoFactory.getAdCatDao().insert(catId, adId);
         response.sendRedirect("/ads");
     }
 }

--- a/src/main/java/com/codeup/adlister/controllers/DeleteAdServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/DeleteAdServlet.java
@@ -20,7 +20,7 @@ public class DeleteAdServlet extends HttpServlet{
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         long id = Long.parseLong(request.getParameter("id"));
         Ads adsDao = DaoFactory.getAdsDao();
-        adsDao.delete(id);
+        //adsDao.delete(id);
         response.sendRedirect("/ads");
 //        User user = (User) request.getSession().getAttribute("user");
 //        if (user == null) {

--- a/src/main/java/com/codeup/adlister/controllers/SearchAdsServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/SearchAdsServlet.java
@@ -11,7 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 
-@WebServlet(name = "controllers.SeachAdsServlet", urlPatterns = "/search/")
+@WebServlet(name = "controllers.SearchAdsServlet", urlPatterns = "/search/")
 public class SearchAdsServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {

--- a/src/main/java/com/codeup/adlister/controllers/SearchAdsServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/SearchAdsServlet.java
@@ -18,9 +18,6 @@ public class SearchAdsServlet extends HttpServlet {
         String query = request.getParameter("search");
         String type = request.getParameter("type");
         if (query != null && type != null) {
-            if (query.isEmpty()) {
-                query = ""; // this may not work and might have to be handled in ads dao instead
-            }
             List<Ad> adsResult = DaoFactory.getAdsDao().searchAds(query, type);
             request.setAttribute("ads", adsResult);
             request.getRequestDispatcher("/WEB-INF/ads/results.jsp").forward(request, response);

--- a/src/main/java/com/codeup/adlister/controllers/SearchAdsServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/SearchAdsServlet.java
@@ -1,6 +1,7 @@
 package com.codeup.adlister.controllers;
 
 import com.codeup.adlister.dao.DaoFactory;
+import com.codeup.adlister.models.Ad;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -8,6 +9,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 
 @WebServlet(name = "controllers.SeachAdsServlet", urlPatterns = "/search/")
 public class SearchAdsServlet extends HttpServlet {
@@ -17,12 +19,10 @@ public class SearchAdsServlet extends HttpServlet {
         String type = request.getParameter("type");
         if (query != null && type != null) {
             if (query.isEmpty()) {
-                query = "*"; // this may not work and might have to be handled in ads dao instead
+                query = ""; // this may not work and might have to be handled in ads dao instead
             }
-            System.out.println(query);
-            System.out.println(type);
-            // temp -- replace .all() with dao method to match ads by search parameter
-            request.setAttribute("ads", DaoFactory.getAdsDao().all());
+            List<Ad> adsResult = DaoFactory.getAdsDao().searchAds(query, type);
+            request.setAttribute("ads", adsResult);
             request.getRequestDispatcher("/WEB-INF/ads/results.jsp").forward(request, response);
         } else {
             response.sendRedirect("/ads");

--- a/src/main/java/com/codeup/adlister/controllers/UpdateAdServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/UpdateAdServlet.java
@@ -21,8 +21,8 @@ public class UpdateAdServlet extends HttpServlet{
         String query = request.getQueryString();
         Long id = Long.valueOf(query.substring(3));
 
-        Ad curAd = DaoFactory.getAdsDao().findOneAd(id);
-        request.getSession().setAttribute("ad", curAd);
+        //Ad curAd = DaoFactory.getAdsDao().findOneAd(id);
+        //request.getSession().setAttribute("ad", curAd);
 
         request.getRequestDispatcher("/WEB-INF/ads/update_ad.jsp").forward(request, response);
     }
@@ -34,7 +34,7 @@ public class UpdateAdServlet extends HttpServlet{
 
         try {
             Ad ad = new Ad(id, title, description);
-            DaoFactory.getAdsDao().update(ad);
+            //DaoFactory.getAdsDao().update(ad);
             request.getSession().setAttribute("ad", ad);
             response.sendRedirect("/profile");
         } catch (Exception e) {

--- a/src/main/java/com/codeup/adlister/controllers/ViewProfileServlet.java
+++ b/src/main/java/com/codeup/adlister/controllers/ViewProfileServlet.java
@@ -23,14 +23,8 @@ public class ViewProfileServlet extends HttpServlet {
         // get all ads for this user
         // this is another Java solution for something that should be done with a SQL query
         User user = (User) request.getSession().getAttribute("user");
-        List<Ad> ads = DaoFactory.getAdsDao().all();
-        List<Ad> userAds = new LinkedList<>();
-        for (Ad ad: ads) {
-            if (ad.getUserId() == user.getId()) {
-                userAds.add(ad);
-            }
-        }
-        request.setAttribute("ads", userAds);
+        List<Ad> ads = DaoFactory.getAdsDao().getAdsForUser(user.getId());
+        request.setAttribute("ads", ads);
         request.getRequestDispatcher("/WEB-INF/profile.jsp").forward(request, response);
     }
 }

--- a/src/main/java/com/codeup/adlister/dao/AdCats.java
+++ b/src/main/java/com/codeup/adlister/dao/AdCats.java
@@ -1,0 +1,13 @@
+package com.codeup.adlister.dao;
+
+import com.codeup.adlister.models.Ad;
+import com.codeup.adlister.models.AdCat;
+
+import java.util.List;
+
+public interface AdCats {
+    // get a list of all the ads
+    List<AdCat> all();
+    // insert a new ad and return the new ad's id
+    Long insert(long catId, long adId);
+}

--- a/src/main/java/com/codeup/adlister/dao/Ads.java
+++ b/src/main/java/com/codeup/adlister/dao/Ads.java
@@ -1,6 +1,7 @@
 package com.codeup.adlister.dao;
 
 import com.codeup.adlister.models.Ad;
+import com.codeup.adlister.models.User;
 
 import java.util.List;
 
@@ -10,4 +11,6 @@ public interface Ads {
     // insert a new ad and return the new ad's id
     Long insert(Ad ad);
     Ad getAd(long id);
+
+    List<Ad> getAdsForUser(long userId);
 }

--- a/src/main/java/com/codeup/adlister/dao/Ads.java
+++ b/src/main/java/com/codeup/adlister/dao/Ads.java
@@ -13,4 +13,6 @@ public interface Ads {
     Ad getAd(long id);
 
     List<Ad> getAdsForUser(long userId);
+
+    List<Ad> searchAds(String query, String type);
 }

--- a/src/main/java/com/codeup/adlister/dao/Ads.java
+++ b/src/main/java/com/codeup/adlister/dao/Ads.java
@@ -9,4 +9,5 @@ public interface Ads {
     List<Ad> all();
     // insert a new ad and return the new ad's id
     Long insert(Ad ad);
+    Ad getAd(long id);
 }

--- a/src/main/java/com/codeup/adlister/dao/Categories.java
+++ b/src/main/java/com/codeup/adlister/dao/Categories.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface Categories {
     List<Category> all();
     Long insert(Category category);
+
+    List<Category> getCatsForAdId(long id);
 }

--- a/src/main/java/com/codeup/adlister/dao/DaoFactory.java
+++ b/src/main/java/com/codeup/adlister/dao/DaoFactory.java
@@ -3,6 +3,7 @@ package com.codeup.adlister.dao;
 public class DaoFactory {
     private static Ads adsDao;
     private static Users usersDao;
+    private static Categories categoriesDao;
     private static Config config = new Config();
 
     public static Ads getAdsDao() {
@@ -17,5 +18,12 @@ public class DaoFactory {
             usersDao = new MySQLUsersDao(config);
         }
         return usersDao;
+    }
+
+    public static Categories getCategoriesDao() {
+        if (categoriesDao == null) {
+            categoriesDao = new MySQLCategoriesDao(config);
+        }
+        return categoriesDao;
     }
 }

--- a/src/main/java/com/codeup/adlister/dao/DaoFactory.java
+++ b/src/main/java/com/codeup/adlister/dao/DaoFactory.java
@@ -4,6 +4,7 @@ public class DaoFactory {
     private static Ads adsDao;
     private static Users usersDao;
     private static Categories categoriesDao;
+    private static AdCats adCatsDao;
     private static Config config = new Config();
 
     public static Ads getAdsDao() {
@@ -25,5 +26,12 @@ public class DaoFactory {
             categoriesDao = new MySQLCategoriesDao(config);
         }
         return categoriesDao;
+    }
+
+    public static AdCats getAdCatDao() {
+        if (adCatsDao == null) {
+            adCatsDao = new MySQLAdCatsDao(config);
+        }
+        return adCatsDao;
     }
 }

--- a/src/main/java/com/codeup/adlister/dao/MySQLAdCatsDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLAdCatsDao.java
@@ -46,7 +46,7 @@ public class MySQLAdCatsDao implements AdCats {
             stmt.executeUpdate();
             ResultSet rs = stmt.getGeneratedKeys();
             rs.next();
-            return rs.getLong(1);
+            return 1L;
         } catch (SQLException e) {
             throw new RuntimeException("Error creating new ad-cat link", e);
         }

--- a/src/main/java/com/codeup/adlister/dao/MySQLAdCatsDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLAdCatsDao.java
@@ -1,0 +1,69 @@
+package com.codeup.adlister.dao;
+
+import com.codeup.adlister.models.Ad;
+import com.codeup.adlister.models.AdCat;
+import com.mysql.cj.jdbc.Driver;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MySQLAdCatsDao implements AdCats {
+    private Connection connection;
+
+    public MySQLAdCatsDao(Config config) {
+        try {
+            DriverManager.registerDriver(new Driver());
+            connection = DriverManager.getConnection(
+                    config.getUrl(),
+                    config.getUser(),
+                    config.getPassword()
+            );
+        } catch (SQLException e) {
+            throw new RuntimeException("Error connecting to the database!", e);
+        }
+    }
+
+    @Override
+    public List<AdCat> all() {
+        PreparedStatement stmt = null;
+        try {
+            stmt = connection.prepareStatement("SELECT * FROM ads");
+            ResultSet rs = stmt.executeQuery();
+            return createAdCatsFromResults(rs);
+        } catch (SQLException e) {
+            throw new RuntimeException("Error retrieving all ads.", e);
+        }
+    }
+
+    @Override
+    public Long insert(long catId, long adId) {
+        String query = "INSERT INTO ad_cat(category_id, ad_id) VALUES (?, ?)";
+        try {
+            PreparedStatement stmt = connection.prepareStatement(query, Statement.RETURN_GENERATED_KEYS);
+            stmt.setLong(1, catId);
+            stmt.setLong(2, adId);
+            stmt.executeUpdate();
+            ResultSet rs = stmt.getGeneratedKeys();
+            rs.next();
+            return rs.getLong(1);
+        } catch (SQLException e) {
+            throw new RuntimeException("Error creating new ad-cat link", e);
+        }
+    }
+
+    private List<AdCat> createAdCatsFromResults(ResultSet rs) throws SQLException {
+        List<AdCat> adCats = new ArrayList<>();
+        while (rs.next()) {
+            adCats.add(extractAd(rs));
+        }
+        return adCats;
+    }
+
+    private AdCat extractAd(ResultSet rs) throws SQLException {
+        return new AdCat(
+                rs.getLong("ad_id"),
+                rs.getLong("category_id")
+        );
+    }
+}

--- a/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
@@ -61,7 +61,9 @@ public class MySQLAdsDao implements Ads {
             String sql = "SELECT * FROM ads WHERE id = ?;";
             PreparedStatement stmt = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
             stmt.setLong(1, id);
-            ad = extractAd(stmt.executeQuery());
+            ResultSet rs = stmt.executeQuery();
+            rs.next();
+            ad = extractAd(rs);
         } catch (SQLException e) {
             System.out.println("SQL Exception: " + e);
         }

--- a/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
@@ -1,6 +1,7 @@
 package com.codeup.adlister.dao;
 
 import com.codeup.adlister.models.Ad;
+import com.codeup.adlister.models.User;
 import com.mysql.cj.jdbc.Driver;
 
 import java.io.FileInputStream;
@@ -68,6 +69,21 @@ public class MySQLAdsDao implements Ads {
             System.out.println("SQL Exception: " + e);
         }
         return ad;
+    }
+
+    @Override
+    public List<Ad> getAdsForUser(long userId) {
+        List<Ad> ads = new ArrayList<>();
+        try {
+            String sql = "SELECT * FROM ads WHERE user_id = ?";
+            PreparedStatement stmt = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            stmt.setLong(1, userId);
+            ResultSet rs = stmt.executeQuery();
+            ads = createAdsFromResults(rs);
+        } catch (SQLException e) {
+            System.out.println("SQL Exception: " + e);
+        }
+        return ads;
     }
 
     private Ad extractAd(ResultSet rs) throws SQLException {

--- a/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
@@ -49,7 +49,7 @@ public class MySQLAdsDao implements Ads {
             stmt.executeUpdate();
             ResultSet rs = stmt.getGeneratedKeys();
             rs.next();
-            return rs.getLong(1);
+            return rs.getLong("id");
         } catch (SQLException e) {
             throw new RuntimeException("Error creating a new ad.", e);
         }

--- a/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
@@ -49,7 +49,7 @@ public class MySQLAdsDao implements Ads {
             stmt.executeUpdate();
             ResultSet rs = stmt.getGeneratedKeys();
             rs.next();
-            return rs.getLong("id");
+            return rs.getLong(1);
         } catch (SQLException e) {
             throw new RuntimeException("Error creating a new ad.", e);
         }

--- a/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
@@ -55,6 +55,19 @@ public class MySQLAdsDao implements Ads {
         }
     }
 
+    public Ad getAd(long id) {
+        Ad ad = null;
+        try {
+            String sql = "SELECT * FROM ads WHERE id = ?;";
+            PreparedStatement stmt = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            stmt.setLong(1, id);
+            ad = extractAd(stmt.executeQuery());
+        } catch (SQLException e) {
+            System.out.println("SQL Exception: " + e);
+        }
+        return ad;
+    }
+
     private Ad extractAd(ResultSet rs) throws SQLException {
         return new Ad(
             rs.getLong("id"),

--- a/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLAdsDao.java
@@ -86,6 +86,21 @@ public class MySQLAdsDao implements Ads {
         return ads;
     }
 
+    @Override
+    public List<Ad> searchAds(String query, String type) {
+        List<Ad> ads = new ArrayList<>();
+        try {
+            String sql = "SELECT * FROM ads WHERE title LIKE ?";
+            PreparedStatement stmt = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            stmt.setString(1, '%' + query + '%');
+            ResultSet rs = stmt.executeQuery();
+            ads = createAdsFromResults(rs);
+        } catch (SQLException e) {
+            System.out.println("SQL Exception: " + e);
+        }
+        return ads;
+    }
+
     private Ad extractAd(ResultSet rs) throws SQLException {
         return new Ad(
             rs.getLong("id"),

--- a/src/main/java/com/codeup/adlister/dao/MySQLCategoriesDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLCategoriesDao.java
@@ -39,7 +39,7 @@ public class MySQLCategoriesDao implements Categories {
     public Long insert(Category category) {
         // check if category already exists before adding a new one
         Category catExisting = findByCategory(category.getName());
-        if (catExisting.getName() != null) {
+        if (catExisting != null) {
             return catExisting.getId();
         } else {
             try {
@@ -50,7 +50,7 @@ public class MySQLCategoriesDao implements Categories {
                 stmt.executeUpdate();
                 ResultSet rs = stmt.getGeneratedKeys();
                 rs.next();
-                return rs.getLong("id");
+                return rs.getLong(1);
             } catch (SQLException e) {
                 throw new RuntimeException("Error creating a new category.", e);
             }
@@ -73,11 +73,16 @@ public class MySQLCategoriesDao implements Categories {
     }
 
     public Category findByCategory(String category) {
-        String query = "SELECT * FROM categories WHERE name = ? LIMIT 1";
         try {
+            String query = "SELECT * FROM categories WHERE name = ? LIMIT 1";
             PreparedStatement stmt = connection.prepareStatement(query);
             stmt.setString(1, category);
-            return extractCategory(stmt.executeQuery());
+            ResultSet rs = stmt.executeQuery();
+            if (rs.next()) {
+                return extractCategory(rs);
+            } else {
+                return null;
+            }
         } catch (SQLException e) {
             throw new RuntimeException("Error finding category", e);
         }

--- a/src/main/java/com/codeup/adlister/dao/MySQLCategoriesDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLCategoriesDao.java
@@ -57,6 +57,21 @@ public class MySQLCategoriesDao implements Categories {
         }
     }
 
+    @Override
+    public List<Category> getCatsForAdId(long id) {
+        try {
+            String sql = "SELECT * FROM categories cat JOIN ad_cat ac on cat.id = ac.category_id WHERE ac.ad_id = ?";
+            PreparedStatement stmt = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            stmt.setLong(1, id);
+            ResultSet rs = stmt.executeQuery();
+            return createCategoriesFromResults(rs);
+        } catch (SQLException e) {
+            System.out.println("Error retrieving categories for ad id " + id);
+        }
+        // if no categories match the given ad id, return an empty list
+        return new ArrayList<>();
+    }
+
     private Category extractCategory(ResultSet rs) throws SQLException {
         return new Category(
                 rs.getLong("id"),

--- a/src/main/java/com/codeup/adlister/dao/MySQLUsersDao.java
+++ b/src/main/java/com/codeup/adlister/dao/MySQLUsersDao.java
@@ -34,6 +34,17 @@ public class MySQLUsersDao implements Users {
         }
     }
 
+    public User findById(long id) {
+        String query = "SELECT * FROM users WHERE id = ? LIMIT 1";
+        try {
+            PreparedStatement stmt = connection.prepareStatement(query);
+            stmt.setLong(1, id);
+            return extractUser(stmt.executeQuery());
+        } catch (SQLException e) {
+            throw new RuntimeException("Error finding a user by username", e);
+        }
+    }
+
     @Override
     public Long insert(User user) throws SQLIntegrityConstraintViolationException {
         String query = "INSERT INTO users(username, email, password) VALUES (?, ?, ?)";

--- a/src/main/java/com/codeup/adlister/dao/Users.java
+++ b/src/main/java/com/codeup/adlister/dao/Users.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface Users {
     User findByUsername(String username);
     Long insert(User user) throws SQLIntegrityConstraintViolationException;
+    User findById(long userId);
 }

--- a/src/main/java/com/codeup/adlister/models/AdCat.java
+++ b/src/main/java/com/codeup/adlister/models/AdCat.java
@@ -1,0 +1,27 @@
+package com.codeup.adlister.models;
+
+public class AdCat {
+    private long adId;
+    private long categoryId;
+
+    public AdCat(long adId, long categoryId) {
+        this.adId = adId;
+        this.categoryId = categoryId;
+    }
+
+    public long getAdId() {
+        return adId;
+    }
+
+    public void setAdId(long adId) {
+        this.adId = adId;
+    }
+
+    public long getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(long categoryId) {
+        this.categoryId = categoryId;
+    }
+}

--- a/src/main/java/com/codeup/adlister/models/Category.java
+++ b/src/main/java/com/codeup/adlister/models/Category.java
@@ -4,8 +4,14 @@ public class Category {
     private long id;
     private String name;
 
+    public Category() {}
+
     public Category(long id, String name) {
         this.id = id;
+        this.name = name;
+    }
+
+    public Category(String name) {
         this.name = name;
     }
 

--- a/src/main/webapp/WEB-INF/ads/ad.jsp
+++ b/src/main/webapp/WEB-INF/ads/ad.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <jsp:include page="/WEB-INF/partials/head.jsp">
-        <jsp:param name="title" value="placeholder" />
+        <jsp:param name="title" value="${ad.title} | AdLister" />
     </jsp:include>
 </head>
 <body>
@@ -20,10 +20,14 @@
         </c:forEach>
     </ul>
 </div>
-<div class="container">
-    <button type="button" class="btn btn-primary">Update listing</button>
-    <button type="button" class="btn btn-danger">Delete listing</button>
-</div>
+<%-- this c:if test is commented out for sake of convenience of debugging the ad update/delete --%>
+<%-- when features are finished it should be reenabled so only the poster can change their ad --%>
+<%--<c:if test="${sessionScope.user.id == ad.userId}">--%>
+    <div class="container">
+        <button type="button" class="btn btn-primary">Update listing</button>
+        <button type="button" class="btn btn-danger">Delete listing</button>
+    </div>
+<%--</c:if>--%>
 <jsp:include page="/WEB-INF/partials/bootstrap-scripts.jsp" />
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/ads/ad.jsp
+++ b/src/main/webapp/WEB-INF/ads/ad.jsp
@@ -12,9 +12,10 @@
     <h1><c:out value="${ad.title}" /></h1>
     <p>Posted by: <c:out value="${user.username}" /></p>
     <p><c:out value="${ad.description}" /></p>
-    <ul class="list-group list-group-horizontal-sm">
+    <ul class="list-group list-group-horizontal-sm my-2 mx-0">
+        <li class="list-group-item list-group-item-light p-2">Tags:</li>
         <c:forEach var="category" items="${categories}">
-            <li class="list-group-item">
+            <li class="list-group-item p-2">
                 <c:out value="${category.name}" />
             </li>
         </c:forEach>

--- a/src/main/webapp/WEB-INF/ads/ad.jsp
+++ b/src/main/webapp/WEB-INF/ads/ad.jsp
@@ -10,8 +10,15 @@
 <jsp:include page="/WEB-INF/partials/navbar.jsp" />
 <div class="container">
     <h1><c:out value="${ad.title}" /></h1>
+    <p>Posted by: <c:out value="${user.username}" /></p>
     <p><c:out value="${ad.description}" /></p>
-    <p><c:out value="${ad.userId}" /></p>
+    <ul class="list-group list-group-horizontal-sm">
+        <c:forEach var="category" items="${categories}">
+            <li class="list-group-item">
+                <c:out value="${category.name}" />
+            </li>
+        </c:forEach>
+    </ul>
 </div>
 <div class="container">
     <button type="button" class="btn btn-primary">Update listing</button>

--- a/src/main/webapp/WEB-INF/ads/create.jsp
+++ b/src/main/webapp/WEB-INF/ads/create.jsp
@@ -17,6 +17,10 @@
                 <label for="description">Description</label>
                 <textarea id="description" name="description" class="form-control" type="text"></textarea>
             </div>
+            <div class="form-group">
+                <label for="category">Category</label>
+                <input id="category" name="category" class="form-control" type="text">
+            </div>
             <input type="submit" class="btn btn-block btn-primary">
         </form>
     </div>


### PR DESCRIPTION
This was a big one but I think it should lay the foundations for the rest of the project. Wrote a bunch of SQL and expanded the Java-side part of the database with prepared statements and models for the category tables. Some of this is kind of useless and can probably be cleaned up in a refactor later but I'm still learning this stuff :)

Changes:
- new categories dao sql methods
- sql table migration script had its drop order rearranged to (hopefully) allow easy dropping of everything
- additional constraints on the ad_cat table creation sql script (composite index)
- new ads dao sql methods
- more servlets using ads and categories dao
- ads now take categories when being created and categories are associated with ads in the database through the ad_cat table
- categories are added in ad creation as comma-separated phrases in a text input
- ads now display their categories in the individual ad pages
- search is functional but only for ad titles
- user pages now only display their own ad postings with new sql query methods
- dao factory now can get a categories dao
- squoods (you heard me, squoods) of new sql statements in the other daos

possibly useless changes:
- new adCat bean class
- new adCat dao and interface
- dao factory can now get an adCat dao
- individual ad pages now have the ad title in the window title bar